### PR TITLE
chore: updating fantom rpc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "@axelar-network/axelarjs-ui",
 			"version": "0.4.0",
 			"dependencies": {
-				"@axelar-network/axelarjs-sdk": "0.4.5",
+				"@axelar-network/axelarjs-sdk": "^0.4.6",
 				"@cosmjs/launchpad": "^0.26.5",
 				"@cosmjs/stargate": "^0.26.5",
 				"@keplr-wallet/cosmos": "0.9.9",
@@ -86,9 +86,9 @@
 			}
 		},
 		"node_modules/@axelar-network/axelarjs-sdk": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@axelar-network/axelarjs-sdk/-/axelarjs-sdk-0.4.5.tgz",
-			"integrity": "sha512-YiP0uAMffHVS+OtpG5fxWx1nXW0yZV9XmFUJcuKx7HmsD7T1d+ReQWHRnWR21YKgtk2EF9MwJwbLFmE9Z9z5AQ==",
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/@axelar-network/axelarjs-sdk/-/axelarjs-sdk-0.4.6.tgz",
+			"integrity": "sha512-d/gxxKEcrhWWsJrz3ItE0fjhTgsS9ldlQhPnC2Fgzs+Qd/Akc2NoLmHUzDgb+j/brqQVZEYGLX92d+MRkhXO+g==",
 			"dependencies": {
 				"@terra-money/terra.js": "^3.0.0",
 				"@types/lodash": "^4.14.176",
@@ -25214,9 +25214,9 @@
 	},
 	"dependencies": {
 		"@axelar-network/axelarjs-sdk": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@axelar-network/axelarjs-sdk/-/axelarjs-sdk-0.4.5.tgz",
-			"integrity": "sha512-YiP0uAMffHVS+OtpG5fxWx1nXW0yZV9XmFUJcuKx7HmsD7T1d+ReQWHRnWR21YKgtk2EF9MwJwbLFmE9Z9z5AQ==",
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/@axelar-network/axelarjs-sdk/-/axelarjs-sdk-0.4.6.tgz",
+			"integrity": "sha512-d/gxxKEcrhWWsJrz3ItE0fjhTgsS9ldlQhPnC2Fgzs+Qd/Akc2NoLmHUzDgb+j/brqQVZEYGLX92d+MRkhXO+g==",
 			"requires": {
 				"@terra-money/terra.js": "^3.0.0",
 				"@types/lodash": "^4.14.176",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.4.0",
 	"private": true,
 	"dependencies": {
-		"@axelar-network/axelarjs-sdk": "0.4.5",
+		"@axelar-network/axelarjs-sdk": "0.4.6",
 		"@cosmjs/launchpad": "^0.26.5",
 		"@cosmjs/stargate": "^0.26.5",
 		"@keplr-wallet/cosmos": "0.9.9",


### PR DESCRIPTION
## Description
update sdk version to 0.4.6 that includes latest Fantom RPC endpoint we need to use. 

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes