### PR TITLE
chore: update releases links

### DIFF
--- a/src/config/downstreamServices.ts
+++ b/src/config/downstreamServices.ts
@@ -52,10 +52,10 @@ blockExplorers.testnet = blockExplorers.devnet
 blockExplorers.local = blockExplorers.devnet
 
 const tokenContracts = {
-  local: "https://docs.axelar.dev/#/resources/testnet-releases",
-  devnet: "https://docs.axelar.dev/#/resources/testnet-releases",
-  testnet: "https://docs.axelar.dev/#/resources/testnet-releases",
-  mainnet: "https://docs.axelar.dev/#/resources/mainnet-releases",
+  local: "https://docs.axelar.dev/#/releases/testnet",
+  devnet: "https://docs.axelar.dev/#/releases/testnet",
+  testnet: "https://docs.axelar.dev/#/releases/testnet",
+  mainnet: "https://docs.axelar.dev/#/releases/mainnet",
 }
 
 const configs: IConfig = {


### PR DESCRIPTION
The location of `mainnet-releases` and `testnet-releases` has changed on docs.axelar.dev.  This PR updates those links:

* `resources/testnet-releases` -> `releases/testnet`
* `resources/mainnet-releases` -> `releases/mainnet`

Currently both old and new locations are supported so there is no urgency.

# Check

I just did a search-and-replace.  Is there anything else that needs to change?