### PR TITLE
removing erc20 warning for native assets on EVM

### DIFF
--- a/src/pages/app/parts/swap-widget/TransactionStatusWindow/index.tsx
+++ b/src/pages/app/parts/swap-widget/TransactionStatusWindow/index.tsx
@@ -288,7 +288,7 @@ const TransactionStatusWindow = ({
         )
       },
     }
-    if (sourceChain?.module === "evm" && activeStep === 2 && !userConfirmed) {
+    if (sourceChain?.module === "evm" && activeStep === 2 && !userConfirmed && sourceChain.chainName.toLowerCase() !== selectedSourceAsset?.native_chain) {
       const message: any = (
         <div>
           Be sure to send only the{" "}


### PR DESCRIPTION
## Description
removing erc20 warning for native assets on EVM chains. the popup is not needed there and may even cause confusion to users when they see it. 

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes